### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,9 @@
+### Change Description
 
-### Description of changes: 
-
-Describe Kani's current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.
-
-### Resolved issues:
+<!-- Describe how your changes improve Kani. Please provide some context on the problem you are solving. -->
 
 Resolves #ISSUE-NUMBER
 
-### Related RFC:
+<!-- Optional: Add the Tracking RFC if relevant. -->
 
-<!--
-Link to the Tracking RFC issue if this work implements part of an RFC.
--->
-Optional #ISSUE-NUMBER.
-
-### Call-outs:
-
-<!-- 
-Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
--->
-
-### Testing:
-
-* How is this change tested?
-
-* Is this a refactor change?
-
-### Checklist
-- [ ] Each commit message has a non-empty body, explaining why the change was made
-- [ ] Methods or procedures are documented
-- [ ] Regression or unit tests are included, or existing tests cover the modified code
-- [ ] My PR is restricted to a single feature or bugfix
-
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
+Note: By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.


### PR DESCRIPTION
### Change Description

Change the template to be more concise to address the team's concern that the template was too verbose.

### Call-outs

1. I don't think we need the disclaimer at the bottom, but I'm keeping it for now.
2. BTW, I do like the call-outs to provide context to the PR, but I believe we can leave it to the author's discretion.

Note: By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
