### PR TITLE
Run benchcomp if PR is labeled 'Z-BenchCI'

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,14 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Run performance benchmarks comparing two different Kani versions.
+# This workflow takes much longer than other workflows, so we don't run it by default.
+# This workflow will run when:
+#  - Changes are pushed to 'main'.
+#  - The PR was manually labeled with 'Z-BenchCI'
+#  - Invoked by the labeler workflow after a PR update.
+#    - Adding 'Z-BenchCI' is not enough. For more details see:
+#      https://github.com/model-checking/kani/issues/2606#issuecomment-1749706887
 name: Kani Performance Benchmarks
 on:
   push:
@@ -8,15 +17,24 @@ on:
   pull_request:
     types:
       - labeled
+  # Allow call after labeler job
+  workflow_call:
+    inputs:
+      base:
+        description: 'The original reference used as base of comparison'
+        required: true
+        type: string
+      head:
+        description: 'The head reference used as the target commit of the comparison'
+        required: true
+        type: string
 
 jobs:
   perf-benchcomp:
-    if: ${{ github.event_name == 'push' 
-      || (github.event_name == 'pull_request' 
-         && github.event.action == 'labeled'
-         && github.event.label.name == 'Z-BenchCI')
-      }}
     runs-on: ubuntu-20.04
+    if: ${{ github.event_name != 'pull_request'
+          || (github.event.action == 'labeled'
+            && github.event.label.name == 'Z-BenchCI') }}
     steps:
       - name: Save push event HEAD and HEAD~ to environment variables
         if: ${{ github.event_name == 'push' }}
@@ -29,6 +47,12 @@ jobs:
         run: |
           echo "OLD_REF=${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_ENV"
           echo "NEW_REF=${{ github.event.pull_request.head.sha }}" | tee -a "$GITHUB_ENV"
+
+      - name: Save input head and base to environment variables
+        if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch"]'), github.event_name) }}
+        run: |
+          echo "OLD_REF=${{ inputs.base }}" | tee -a "$GITHUB_ENV"
+          echo "NEW_REF=${{ inputs.head }}" | tee -a "$GITHUB_ENV"
 
       - name: Check out Kani (old variant)
         uses: actions/checkout@v3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,9 +3,9 @@
 #
 # Auto label PRs based on the files that were changed
 #
-# This PR runs on `pull_request_target` because it needs extra write permission.
+# This workflow runs on `pull_request_target` because it needs extra write permission.
 #
-# Thus, we keep this workflow minimal, and the only action used here is from a
+# Thus, we keep this workflow minimal, and the only actions used here are from the same
 # verified publisher.
 #
 # See <https://github.com/actions/labeler/issues/121> for more details.
@@ -24,7 +24,16 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Label PR
+      id: labeler
       uses: actions/labeler@v4
       with:
         dot: true
 
+    - name: Trigger Benchmarks
+      # Use restrictive permissions.
+      permissions: {}
+      if: contains(steps.labeler.outputs.all-labels, 'Z-BenchCI')
+      uses: ./.github/workflows/bench.yml
+      with:
+        base: ${{ github.event.pull_request.base.sha }}
+        head: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
The "Auto Label" workflow correctly label our PRs; however, this action do not trigger a PR 'labeled' workflow. To automatically do that, we now trigger the benchmark workflow from the labeler workflow.

In this PR, we also change the workflow to run after any update to a PR that has the 'Z-BenchCI' label.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
